### PR TITLE
Upgrade injectable to 3.0.1

### DIFF
--- a/chain/__init__.py
+++ b/chain/__init__.py
@@ -7,10 +7,13 @@ use our packages.
 """
 from sys import modules
 from types import ModuleType
+from injectable import InjectionContainer
 from chain.core.domains.state import State
 from chain.core.domains.chain import Decorator
 
 __version__ = "1.0.3"
+
+InjectionContainer.load()
 
 
 class Chain(ModuleType):

--- a/chain/__init__.py
+++ b/chain/__init__.py
@@ -11,7 +11,7 @@ from injectable import InjectionContainer
 from chain.core.domains.state import State
 from chain.core.domains.chain import Decorator
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 InjectionContainer.load()
 

--- a/chain/core/domains/chain/chain.py
+++ b/chain/core/domains/chain/chain.py
@@ -4,8 +4,8 @@ The chain creates a Chain class that will handle the core methods to create chai
 functions using our lib.
 
 """
-from typing import ClassVar, Callable
-from injectable import autowired
+from typing import Callable
+from injectable import autowired, Autowired
 from copy import deepcopy
 from chain.core.domains.state import State
 from chain.core.domains.context import Context
@@ -20,7 +20,11 @@ class Chain:
     """
 
     @autowired
-    def __init__(self, function: Callable, *, initial_state: State) -> ClassVar:
+    def __init__(
+        self,
+        function: Callable,
+        initial_state: Autowired(State, namespace="python-chain"),
+    ):
         self.initial_state = deepcopy(initial_state)
         self.function = function
 

--- a/chain/core/domains/chain/decorator.py
+++ b/chain/core/domains/chain/decorator.py
@@ -4,8 +4,8 @@ The decorator exposes the possibility to create a new decorator to an existing f
 
 """
 from functools import update_wrapper
-from typing import Callable, ClassVar
-from injectable import autowired
+from typing import Callable
+from injectable import autowired, Autowired
 from chain.core.domains.state import State
 from chain.core.domains.chain import Chain
 
@@ -19,6 +19,10 @@ class Decorator(Chain):
     """
 
     @autowired
-    def __init__(self, function: Callable, *, initial_state: State) -> ClassVar:
+    def __init__(
+        self,
+        function: Callable,
+        initial_state: Autowired(State, namespace="python-chain"),
+    ):
         super().__init__(function, initial_state=initial_state)
         update_wrapper(self, function)

--- a/chain/core/domains/state/state.py
+++ b/chain/core/domains/state/state.py
@@ -5,9 +5,13 @@ create some useful methods to be used during a chain.
 
 """
 from typing import ClassVar
+
+from injectable import injectable
+
 from chain.core.domains.context import Context
 
 
+@injectable(namespace="python-chain")
 class State:
     """State Class.
 

--- a/chain/tests/acceptance/steps/step_chain.py
+++ b/chain/tests/acceptance/steps/step_chain.py
@@ -128,7 +128,7 @@ def step_create_decorated_function_with_output(context: dict) -> None:
     def dummy(context: State, expected_output=expected_output) -> None:
         return expected_output
 
-    if 'chain' not in context:
+    if "chain" not in context:
         context.chain = list()
 
     context.expected_output = expected_output
@@ -146,9 +146,9 @@ def step_create_decorated_function_without_output(context: dict) -> None:
 
     @chain
     def bar(context: State) -> None:
-        context.bar = 'bar'
+        context.bar = "bar"
 
-    if 'chain' not in context:
+    if "chain" not in context:
         context.chain = list()
 
     context.expected_output = expected_output

--- a/chain/tests/acceptance/steps/step_common.py
+++ b/chain/tests/acceptance/steps/step_common.py
@@ -72,7 +72,7 @@ def step_run_first_chain_directly(context: dict) -> None:
     """
     result = context.chain[0]()
 
-    if 'results' not in context:
+    if "results" not in context:
         context.results = list()
 
     context.results.append(result)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,3 +1,3 @@
 # Contains requirements common to all environments
 
-injectable==2.0.0
+injectable==3.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.3
+current_version = 1.0.4
 
 [behave]
 paths = chain/tests/acceptance

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,16 @@
 from pip._internal.req import parse_requirements
 from setuptools import setup, find_packages
 
-raw_requirements = parse_requirements('requirements/production.txt', session=False)
+raw_requirements = parse_requirements("requirements/production.txt", session=False)
 requirements = [str(ir.req) for ir in raw_requirements]
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name='python-chain',
-    version='1.0.3',
-    scripts=['bin/build_chain.py'] ,
+    name="python-chain",
+    version="1.0.3",
+    scripts=["bin/build_chain.py"],
     author="QuintoAndar",
     author_email="daniel.fonseca@quintoandar.com.br",
     description="An easy to use pattern of function chaining on Python.",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="python-chain",
-    version="1.0.3",
+    version="1.0.4",
     scripts=["bin/build_chain.py"],
     author="QuintoAndar",
     author_email="daniel.fonseca@quintoandar.com.br",


### PR DESCRIPTION
## ☕ Purpose

This PR upgrades the lib [injectable](https://github.com/allrod5/injectable) from version 2.0.0 to the latest version: 3.0.1.

## 🧐 Checklist

- [x] An enhancement that will work with this PR

## 🐞 Testing

One can use `python setup.py develop` to install this development version of python-chain after cloning this branch and run chains for testing. Also `python setup.py test` can be run to assert all tests are passing.

## 🍩 Further details

State is declared as injectable only under the `python-chain` namespace avoiding conflicts in the global namespace in python code that uses both `python-chain` and `injectable`.